### PR TITLE
Refactor response parsing to help debug `TypeError`

### DIFF
--- a/experimental/chat_langchain/graph.py
+++ b/experimental/chat_langchain/graph.py
@@ -49,11 +49,16 @@ async def analyze_and_route_query(
     messages = [
         {"role": "system", "content": configuration.router_system_prompt}
     ] + state.messages
-    response = cast(
-        Router, await model.with_structured_output(Router).ainvoke(messages)
-    )
-    print(f"router:\n {json.dumps(response)}")
-    return {"router": response}
+
+    model = model.with_structured_output(Router)
+    response = await model.ainvoke(messages)
+    print(f"response:\n {response}")
+    router = {
+        "logic": response.get("logic", ""),
+        "type": response.get("type", "more-info")
+    }
+    print(f"router:\n {json.dumps(router)}")
+    return {"router": router}
 
 
 def route_query(


### PR DESCRIPTION
### Summary
The following error occurs as described [here](https://github.com/magaton/langgraph-mysteries/tree/main/experimental/chat_langchain/mysteries/studio_error): `TypeError: 'NoneType' object is not scriptable`.

This means `state.router` is `None`. We need to figure out why it's `None`. The preceding node, `analyze_and_route_query`, set the `router` key in the graph state.

Clarifications
1. `cast()` does not actually change the type of the object. This is only used for static type checking. See [docs](https://docs.python.org/3/library/typing.html#typing.cast). Based on the error and the original code, `response` is `None` despite the `cast()` function call. It's not "cast" to a `Router` type.

I just want to confirm if `response` is actually `None` in the implementation of `analyze_and_route_query`. Separately, a `Router` type is explicitly set in the state.